### PR TITLE
Ability to pass in a base converter

### DIFF
--- a/simpleflake/simpleflake.py
+++ b/simpleflake/simpleflake.py
@@ -36,10 +36,16 @@ def extract_bits(data, shift, length):
     bitmask = ((1 << length) - 1) << shift
     return ((data & bitmask) >> shift)
 
+
+def dec_to_hex(val):
+    return hex(val).lstrip('0x').rstrip('L').upper()
+
+
 # ==================================================
 
 
-def simpleflake(timestamp=None, random_bits=None, epoch=SIMPLEFLAKE_EPOCH):
+def simpleflake(timestamp=None, random_bits=None, epoch=SIMPLEFLAKE_EPOCH,
+                base_converter=None):
     """Generate a 64 bit, roughly-ordered, globally-unique ID."""
     second_time = timestamp if timestamp is not None else time.time()
     second_time -= epoch
@@ -50,7 +56,10 @@ def simpleflake(timestamp=None, random_bits=None, epoch=SIMPLEFLAKE_EPOCH):
 
     flake = (millisecond_time << SIMPLEFLAKE_TIMESTAMP_SHIFT) + randomness
 
-    return flake
+    if base_converter:
+        return base_converter(flake)
+    else:
+        return flake
 
 
 def parse_simpleflake(flake):

--- a/tests/test.py
+++ b/tests/test.py
@@ -10,6 +10,13 @@ class SimpleFlakeTest(unittest.TestCase):
         flake = sf.simpleflake()
         self.assertEquals(64, len(sf.binary(flake)))
 
+    def test_simpleflake_hex(self):
+        flake = sf.simpleflake(base_converter=sf.dec_to_hex)
+        allowed_chars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                         'A', 'B', 'C', 'D', 'E', 'F']
+        self.assertTrue(set(flake).issubset(allowed_chars))
+        self.assertEquals(64, len(sf.binary(int(flake, 16))))
+
     def test_simpleflake_parts_timestamp(self):
         coolstamp = sf.SIMPLEFLAKE_EPOCH + 1234321.0
         epoch_flake = sf.simpleflake(timestamp=coolstamp)


### PR DESCRIPTION
- When generating a simpleflake you can now pass in a base converter to allow
  easy converting from base 10 to something else
- dec_to_hex converter added in utils area
