### PR TITLE
Consistent hash ID

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='mali+simpleflake@custommade.com',
     description='Twitter snowflake compatible super-simple distributed ID generator.',
     url='https://github.com/SawdustSoftware/simpleflake',
-    version='0.1.5',
+    version='0.1.6',
     packages=['simpleflake', ],
     package_dir={'simpleflake':'simpleflake'},
     license='MIT',

--- a/simpleflake/simpleflake.py
+++ b/simpleflake/simpleflake.py
@@ -44,12 +44,9 @@ def simpleflake(timestamp=None, random_bits=None, epoch=SIMPLEFLAKE_EPOCH):
     second_time = timestamp if timestamp is not None else time.time()
     second_time -= epoch
     millisecond_time = int(second_time * 1000)
-
-    randomness = random.SystemRandom().getrandbits(SIMPLEFLAKE_RANDOM_LENGTH)
-    randomness = random_bits if random_bits is not None else randomness
-
+    randomness = (random_bits if random_bits is not None
+                  else random.SystemRandom().getrandbits(SIMPLEFLAKE_RANDOM_LENGTH))
     flake = (millisecond_time << SIMPLEFLAKE_TIMESTAMP_SHIFT) + randomness
-
     return flake
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python
+
 import random
+import time
 import unittest
 
 import simpleflake as sf
@@ -36,3 +39,18 @@ class SimpleFlakeTest(unittest.TestCase):
         parts = sf.parse_simpleflake(flake)
         self.assertEquals(coolstamp, parts.timestamp)
         self.assertEquals(random_bits, parts.random_bits)
+
+    def test_consistentflake(self):
+        flake = sf.simpleflake()
+        chi = sf.consistent_hash_id(flake)
+        old_flake = flake
+        for i in range(100):
+            new_flake = sf.consistentflake(flake)
+            self.assertEqual(chi, sf.consistent_hash_id(new_flake))
+            self.assertNotEqual(old_flake, new_flake, "%4d: %x" % (i, new_flake))
+            time.sleep(2.0e-4)
+            old_flake = new_flake
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When using Consistent Hashing for Sharding, it is convenient to designate certain bits in the ID as the hash ID. `consistentflake(flake)` generates a new simpleflake with the same hash ID as `flake`. It should be used to generate
associated IDs that all hash to the same shard.

http://en.wikipedia.org/wiki/Consistent_hashing
